### PR TITLE
svd: fix nested register numbering

### DIFF
--- a/src/svd/peripheral.py
+++ b/src/svd/peripheral.py
@@ -688,7 +688,7 @@ def get_memory_map(element: ET.Element, base_address: int) -> Dict[int, Register
 
     memory_map: Dict[int, Register] = {}
 
-    for address, reg in register_bundles.items():
+    for address, reg in sorted(register_bundles.items(), key=lambda x: x[0]):
         instance = instance_counter[reg.name]
         instance_counter[reg.name] += 1
 


### PR DESCRIPTION
Nested registers/clusters were assigned numbers in a breadth-first order, meaning that for a register REG1[n] with dimension N, and a nested register REG1[n].REG2[m],
REG1[0].REG2[0] -> "reg1_reg2_0" but
REG1[0].REG2[1] -> "reg1_reg2_N".

This commit fixes the problem by sorting the registers by address before assigning numbers, making it so numbers are assigned in depth-first order in most cases.

Ref: NCSDK-16427