### PR TITLE
add minimum version requirements to all dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Latest](https://github.com/NordicSemiconductor/svada)
 
+## [v2.0.1](https://github.com/NordicSemiconductor/svada/tree/v2.0.1)
+
+### Fixed
+* NCSDK-24490: Specified minimum version requirements for all dependencies.
+
 ## [v2.0.0](https://github.com/NordicSemiconductor/svada/tree/v2.0.0)
 
 This version is a large expansion of svada to support a lot of new features.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,9 +14,9 @@ classifiers = [
 requires-python = ">=3.8"
 dependencies = [
   "setuptools_scm[toml]>=6.2",
-  "lxml",
-  "numpy",
-  "typing_extensions",
+  "lxml~=4.9",
+  "numpy~=1.21",
+  "typing_extensions>=4.4.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
Add minimum version requirements to ensure that dependency versions are upgraded when svada is installed.

Ref: NCSDK-24490