### PR TITLE
open SVD files in binary mode 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Latest](https://github.com/NordicSemiconductor/svada)
 
+## [v2.0.2](https://github.com/NordicSemiconductor/svada/tree/v2.0.2)
+
+### Fixed
+* NCSDK-24532: SVD files are now opened in binary mode instead of defaulting to the locale preferred encoding.
+  This avoids issues that occur when the locale encoding doesn't match the file encoding.
+
 ## [v2.0.1](https://github.com/NordicSemiconductor/svada/tree/v2.0.1)
 
 ### Fixed

--- a/src/svd/parsing.py
+++ b/src/svd/parsing.py
@@ -92,7 +92,7 @@ def parse(svd_path: Union[str, Path], options: Options = Options()) -> Device:
         class_lookup = _TwoLevelTagLookup(bindings.BINDINGS)
         xml_parser.set_element_class_lookup(class_lookup)
 
-        with open(svd_file, "r") as f:
+        with open(svd_file, "rb") as f:
             xml_device = objectify.parse(f, parser=xml_parser)
 
         t_parse = (perf_counter_ns() - t_parse_start) / 1_000_000


### PR DESCRIPTION
Currently, svada opens SVD files in text mode without specifying an
encoding, which then defaults to system encoding.
This can cause issues when the system encoding doesn't match the file
encoding.
Open SVD files in binary mode instead to avoid the issue.

Ref: NCSDK-24532