### PR TITLE
Update dependencies to support Python 3.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Latest](https://github.com/NordicSemiconductor/svada)
 
+## [v2.1.0](https://github.com/NordicSemiconductor/svada/tree/v2.1.0)
+
+### Changed
+
+* NCSDK-29781: Updated package dependencies to enable support for Python 3.13.
+  Consequently, removed support for Python 3.9 and below.
+
 ## [v2.0.2](https://github.com/NordicSemiconductor/svada/tree/v2.0.2)
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,11 +11,11 @@ classifiers = [
   "Programming Language :: Python :: 3",
   "Topic :: Software Development :: Build Tools",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
   "setuptools_scm[toml]>=6.2",
-  "lxml~=4.9",
-  "numpy~=1.21",
+  "lxml~=5.3",
+  "numpy~=2.1",
   "typing_extensions>=4.4.0",
 ]
 


### PR DESCRIPTION
Depending on older versions of lxml and numpy prevents svada from being installed with Python 3.13, so let's use newer (major) versions. No code changes seem to be required.

Also, since numpy 2.x dropped support for Python 3.9 and below, we must do the same.