### PR TITLE
pyproject: use the hatchling build system

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,0 @@
-include README.md CHANGELOG.md LICENSE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-  "setuptools_scm[toml]>=6.2",
   "lxml~=5.3",
   "numpy~=2.1",
   "typing_extensions>=4.4.0",
@@ -24,17 +23,22 @@ homepage = "https://github.com/nordicsemiconductor/svada"
 repository = "https://github.com/nordicsemiconductor/svada.git"
 
 [build-system]
-requires = ["setuptools>=61", "setuptools_scm[toml]>=6.2"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling", "hatch-vcs"]
+build-backend = "hatchling.build"
 
-[tool.setuptools]
-package-dir = { svd = "src/svd" }
-include-package-data = true
+[tool.hatch.version]
+source = "vcs"
 
-[tool.setuptools.package-data]
-svd = ["py.typed"]
+[tool.hatch.build.targets.sdist]
+packages = ["src/svd"]
 
-[tool.setuptools_scm]
+[tool.hatch.build.targets.wheel]
+packages = [
+  # Used when building the wheel from the sdist
+  "svd",
+  # Used when building the wheel directly
+  "src/svd"
+]
 
 [tool.mypy]
 disallow_untyped_defs = true

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,0 @@
-#
-# Copyright (c) 2022 Nordic Semiconductor ASA
-#
-# SPDX-License-Identifier: Apache-2.0
-#
-
-from setuptools import setup
-
-setup()

--- a/src/svd/__init__.py
+++ b/src/svd/__init__.py
@@ -51,9 +51,6 @@ from .device import (
 
 import importlib.metadata
 
-try:
-    __version__ = importlib.metadata.version("svada")
-except importlib.metadata.PackageNotFoundError:
-    # Package is not installed
-    import setuptools_scm
-    __version__ = setuptools_scm.get_version(root="../..", relative_to=__file__)
+__version__ = importlib.metadata.version("svada")
+
+del importlib.metadata


### PR DESCRIPTION
This simplifies the package build.
Also remove support for running without installing the package.