### PR TITLE
device: Fix off-by-one error in Register.set_content

### DIFF
--- a/src/svd/device.py
+++ b/src/svd/device.py
@@ -16,7 +16,6 @@ many of the operations in this module lazily compute the data needed on first ac
 from __future__ import annotations
 
 import dataclasses as dc
-import math
 import re
 import typing
 from abc import ABC, abstractmethod
@@ -1192,7 +1191,7 @@ class Register(_Register[EPath, "Field"]):
         """
         reg_width = self.bit_width
 
-        if new_content > 0 and math.ceil(math.log2(new_content)) > reg_width:
+        if new_content.bit_length() > reg_width:
             raise SvdMemoryError(
                 f"Value {hex(new_content)} is too large for {reg_width}-bit register {self.path}."
             )


### PR DESCRIPTION
This method does a bit width check to reject values that wouldn't fit in a given register. This used to be done using a floating-point expression which gave wrong results for powers of 2. The correct formula would be:

    math.floor(math.log2(x)) + 1

That said, it's way more efficient to use `int.bit_length` instead.

Note: currently, this fix will not be noticeable to the user, because any register overflows missed by svada would've been caught by numpy.