### PR TITLE
pyproject: temporarily require hatchling<1.27.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ homepage = "https://github.com/nordicsemiconductor/svada"
 repository = "https://github.com/nordicsemiconductor/svada.git"
 
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling<1.27.0", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [tool.hatch.version]


### PR DESCRIPTION
The newest release generates package metadata version 2.4 which is not accepted by PyPi. Temporarily require a lower version.